### PR TITLE
Fixed setting value not saving null.

### DIFF
--- a/migrations/Version20240213140946.php
+++ b/migrations/Version20240213140946.php
@@ -7,25 +7,21 @@ namespace ForumifyDoctrineMigrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
+
 final class Version20240213140946 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return '';
+        return 'Makes settings value nullable';
     }
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE setting CHANGE value value JSON DEFAULT NULL');
     }
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE setting CHANGE value value JSON NOT NULL');
     }
 }

--- a/migrations/Version20240213140946.php
+++ b/migrations/Version20240213140946.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ForumifyDoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240213140946 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE setting CHANGE value value JSON DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE setting CHANGE value value JSON NOT NULL');
+    }
+}

--- a/src/Core/Entity/Setting.php
+++ b/src/Core/Entity/Setting.php
@@ -14,7 +14,7 @@ class Setting
     #[ORM\Column('`key`')]
     private readonly string $key;
 
-    #[ORM\Column(type: 'json')]
+    #[ORM\Column(type: 'json', nullable: true)]
     private mixed $value = null;
 
     public function __construct(string $key)


### PR DESCRIPTION
Bug where if you only fill out one field in the configuration during a fresh installation of forumify, it'll return error that value cannot be null.