### PR TITLE
Add auto attributes for all auth input types

### DIFF
--- a/src/Core/Controller/ForgotPasswordController.php
+++ b/src/Core/Controller/ForgotPasswordController.php
@@ -36,6 +36,7 @@ class ForgotPasswordController extends AbstractController
             ->add('email', EmailType::class, [
                 'label' => 'email',
                 'help' => 'forgot_password.email_help',
+                'attr' => ['autocomplete' => 'email', 'autofocus' => 'true'],
             ])
             ->getForm();
 
@@ -64,8 +65,8 @@ class ForgotPasswordController extends AbstractController
         $form = $this->createFormBuilder()
             ->add('newPassword', RepeatedType::class, [
                 'type' => PasswordType::class,
-                'first_options' => ['label' => 'Password'],
-                'second_options' => ['label' => 'Repeat password'],
+                'first_options' => ['label' => 'Password', 'attr' => ['autocomplete' => 'new-password', 'autofocus' => 'autofocus']],
+                'second_options' => ['label' => 'Repeat password', 'attr' => ['autocomplete' => 'new-password']],
                 'constraints' => [
                     new Assert\NotBlank(),
                     new Assert\Length(min: 8)

--- a/src/Core/Form/RegisterType.php
+++ b/src/Core/Form/RegisterType.php
@@ -29,12 +29,16 @@ class RegisterType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('username', TextType::class)
-            ->add('email', EmailType::class)
+            ->add('username', TextType::class, [
+                'attr' => ['autocomplete' => 'username', 'autofocus' => 'autofocus'],
+            ])
+            ->add('email', EmailType::class, [
+                'attr' => ['autocomplete' => 'email'],
+            ])
             ->add('password', RepeatedType::class, [
                 'type' => PasswordType::class,
-                'first_options' => ['label' => 'Password'],
-                'second_options' => ['label' => 'Repeat password'],
+                'first_options' => ['label' => 'Password', 'attr' => ['autocomplete' => 'new-password']],
+                'second_options' => ['label' => 'Repeat password', 'attr' => ['autocomplete' => 'new-password']],
             ])
             ->add('timezone', ChoiceType::class, [
                 'autocomplete' => true,

--- a/templates/frontend/auth/login.html.twig
+++ b/templates/frontend/auth/login.html.twig
@@ -21,12 +21,12 @@
         {% block login_form %}
             <div class="form-row">
                 <label for="username" class="labels">{{ identifierLabel }}</label>
-                <input type="text" id="username" name="_username" value="{{ last_username }}" placeholder="{{ identifierLabel }}">
+                <input type="text" id="username" name="_username" value="{{ last_username }}" placeholder="{{ identifierLabel }}" autofocus="autofocus" autocomplete="username">
             </div>
 
             <div class="form-row">
                 <label for="password" class="labels">{{ 'password'|trans }}</label>
-                <input type="password" id="password" name="_password" placeholder="{{ 'password'|trans }}">
+                <input type="password" id="password" name="_password" placeholder="{{ 'password'|trans }}" autocomplete="current-password">
             </div>
         {% endblock %}
 


### PR DESCRIPTION
This PR adds all `auto` attributes to the applicable `input` fields for the register, forgot password, search, and login forms to aid in faster and more accurate form completion while taking advantage of native browser functions.

Side note: The token in `/forgot-password` is not validated and the form can be submitted with anything in that parameter path. Make want to validate the JWT before rending the form?