### PR TITLE
Added profile widget block

### DIFF
--- a/templates/frontend/profile/profile.html.twig
+++ b/templates/frontend/profile/profile.html.twig
@@ -6,19 +6,17 @@
     </div>
     <div class="grid gap-4">
             <div class="col-xs-12 col-md-4">
-                {% block profile_widgets %}
-                    {% block profile_badges %}
-                        <div class="card">
-                            <div class="card-title">
-                                {{ 'profile.badges'|trans }}
-                            </div>
-                            <div class="card-body grid-xs-6 grid-md-4 gap-4">
-                                {% for badge in user.badges %}
-                                    <img width="100%" height="auto" src="{{ asset(badge.image, 'forumify.asset') }}" title="{{ badge.name }}">
-                                {% endfor %}
-                            </div>
+                {% block profile_badges %}
+                    <div class="card">
+                        <div class="card-title">
+                            {{ 'profile.badges'|trans }}
                         </div>
-                    {% endblock %}
+                        <div class="card-body grid-xs-6 grid-md-4 gap-4">
+                            {% for badge in user.badges %}
+                                <img width="100%" height="auto" src="{{ asset(badge.image, 'forumify.asset') }}" title="{{ badge.name }}">
+                            {% endfor %}
+                        </div>
+                    </div>
                 {% endblock %}
             </div>
         {% block profile_activity %}

--- a/templates/frontend/profile/profile.html.twig
+++ b/templates/frontend/profile/profile.html.twig
@@ -5,20 +5,22 @@
         {{ component('Forumify\\ProfileHeader', { user: user }) }}
     </div>
     <div class="grid gap-4">
-        {% block profile_badges %}
             <div class="col-xs-12 col-md-4">
-                <div class="card">
-                    <div class="card-title">
-                        {{ 'profile.badges'|trans }}
-                    </div>
-                    <div class="card-body grid-xs-6 grid-md-4 gap-4">
-                        {% for badge in user.badges %}
-                            <img width="100%" height="auto" src="{{ asset(badge.image, 'forumify.asset') }}" title="{{ badge.name }}">
-                        {% endfor %}
-                    </div>
-                </div>
+                {% block profile_widgets %}
+                    {% block profile_badges %}
+                        <div class="card">
+                            <div class="card-title">
+                                {{ 'profile.badges'|trans }}
+                            </div>
+                            <div class="card-body grid-xs-6 grid-md-4 gap-4">
+                                {% for badge in user.badges %}
+                                    <img width="100%" height="auto" src="{{ asset(badge.image, 'forumify.asset') }}" title="{{ badge.name }}">
+                                {% endfor %}
+                            </div>
+                        </div>
+                    {% endblock %}
+                {% endblock %}
             </div>
-        {% endblock %}
         {% block profile_activity %}
             {% include '@Forumify/frontend/components/profile_activity.html.twig' %}
         {% endblock %}


### PR DESCRIPTION
Adds a profile_widgets block under the `col-xs-12 col-md-4` div so plugin developers can override that block and add their own blocks to it. 

Also moved profile_badges block under profile_widgets for formatting reasons. _So any new blocks that are added are under/on top of the profile_badges and not side to side._