### PR TITLE
fix logout on role change

### DIFF
--- a/src/Core/Entity/User.php
+++ b/src/Core/Entity/User.php
@@ -119,12 +119,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     public function getRoles(): array
     {
-        $roles = ['ROLE_USER'];
-        foreach ($this->roles as $role) {
-            $roles[] = $role->getRoleName();
-        }
-
-        return array_unique($roles);
+        return ['ROLE_USER'];
     }
 
     /**

--- a/src/Core/EventSubscriber/LastActivityListener.php
+++ b/src/Core/EventSubscriber/LastActivityListener.php
@@ -23,8 +23,14 @@ class LastActivityListener
     public function __invoke(): void
     {
         $user = $this->security->getUser();
-        if ($user instanceof User) {
-            $user->setLastActivity(new DateTime());
+        if (!$user instanceof User) {
+            return;
+        }
+
+        $now = new DateTime();
+        $lastActivity = $user->getLastActivity();
+        if ($lastActivity === null || $now->getTimestamp() - $lastActivity->getTimestamp() >= 60) {
+            $user->setLastActivity($now);
             $this->userRepository->save($user);
         }
     }


### PR DESCRIPTION
The only place we used symfony based role auth was for the super admin voter. Everything else already used the roles from the database and their permissions. So we can safely always return ROLE_USER without any other roles for logged in users.
fixes #119